### PR TITLE
configurable lever max/min value & analog xinput joystick

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ xinput=1    ; Enable buttons and lever emulation with XInput if connected. Other
 mouse=1     ; Enable lever emulation with mouse. Disable to move the lever with keyboard.
 keyboard=1  ; Enable buttons and lever emulation with keyboard. If mouse emulation is enabled, lever from keyboard will be ignored.
 
+ontrollerLeverMin=100  ; Ontroller minimum lever value, press FN1+FN2 and move lever to the left to check your lever value in inject.exe terminal
+ontrollerLeverMax=600  ; Ontroller maximum lever value, press FN1+FN2 and move lever to the right to check your lever value in inject.exe terminal
+xinputAnalogLever=0    ; Use XInput left joystick as analog value
+
 ; Keyboard & Mouse bindings
 ; See the following link for complete list of virtual keycodes:
 ; https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes


### PR DESCRIPTION
- Configurable ontroller lever min/max value. To help determined values, it can be viewed in the inject.exe log by pressing FN1+FN2 buttons. The default values are set at 100/600
- Ontroller lever will now utilized both sides of the lever (uses range of -32767 to 32767)
- Analog XInput mode to make left joystick behave exactly the same as arcade lever
